### PR TITLE
dev: use native docker compose

### DIFF
--- a/scripts/db/start
+++ b/scripts/db/start
@@ -2,4 +2,4 @@
 
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 cd $SCRIPTPATH
-docker-compose up -d
+docker compose up -d


### PR DESCRIPTION
Updates the db start script to use `docker compose` instead of `docker-compose` - the latter has been deprecated.