### PR TITLE
Making emoji is visible on other screen on the same room

### DIFF
--- a/hooks/chat/useRoomReactions.tsx
+++ b/hooks/chat/useRoomReactions.tsx
@@ -22,7 +22,7 @@ export const useRoomReactions = (roomName: string, username?: string) => {
   useEffect(() => {
     // Define the reaction listener that will handle incoming reactions
     const handleAddRoomReaction: RoomReactionListener = (reaction) => {
-      if (reaction.isSelf) return
+      // if (reaction.isSelf) return
       setLatestRoomReaction(reaction)
     }
     // Subscribe to room reactions with the defined listener


### PR DESCRIPTION
Since it is a real-time application implementation was expecting to see the emojis on other screens too.
Initially: 

https://github.com/user-attachments/assets/5932cb1f-73dd-4332-9609-477392ee240a

By commenting out "if (reaction.isSelf) return" on useRoomReactions hook

Updated: 