### PR TITLE
Remove deprecated [chat] usage.

### DIFF
--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest) {
   // Create JWT claims
   const claims = {
     "x-ably-capability": JSON.stringify({
-      "[chat]*": ["*"],
+      "chat:*": ["*"],
     }),
     "x-ably-clientId": clientIdParam,
     iat: Math.floor(Date.now() / 1000),

--- a/lib/room.ts
+++ b/lib/room.ts
@@ -5,7 +5,7 @@ const alphanumeric =
 const nanoid = customAlphabet(alphanumeric, 12)
 
 export const generateRoomName = () => {
-  return nanoid()
+  return "chat:" + nanoid()
 }
 
 export const isValidRoom = (room: string | null) => {
@@ -16,6 +16,14 @@ export const isValidRoom = (room: string | null) => {
 
   if (room.length < 12 || room.length > 24) {
     console.info("Room must be between 12 and 24 characters")
+    return false
+  }
+
+  // Rooms must be prefixed with `chat` i.e chat:12345, since we have defined our capabilities with a custom prefix like so: "chat:*": ["*"]
+  // This is an example of namespacing, and is useful for managing larger applications with complex capability structures.
+  // Other prefixes could be `video:`, `news:`, `sports:`, etc.
+  if (!room.startsWith("chat:")) {
+    console.info("Room must start with 'chat:' prefix")
     return false
   }
 


### PR DESCRIPTION
We were still using the old [chat] when requesting capabilities. 